### PR TITLE
Fix for query.hasOwnProperty being undefined in node v6+

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ Urly.prototype.map = function(url, extraParams) {
 
         // Check if we have all the required query params
         var missingQueryParams = this._mappings[i].query.filter(function(key) {
-            return !query.hasOwnProperty(key) || query[key] == '';
+            return !Object.prototype.hasOwnProperty.call(query, key) || query[key] == '';
         });
 
         if (missingQueryParams.length) {


### PR DESCRIPTION
See https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#querystring

- The parsed object returned by `querystring.parse()` now inherits
  from `Object.create(null)` rather than `Object.prototype`

Related to https://github.com/ifwe/monocle-api/pull/68